### PR TITLE
EVA-612 More robust equality check for VariantSourceEntry

### DIFF
--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/VariantSourceEntry.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/VariantSourceEntry.java
@@ -211,10 +211,10 @@ public class VariantSourceEntry {
         if (!Objects.equals(this.format, other.format)) {
             return false;
         }
-        if (!Objects.equals(this.samplesData, other.samplesData)) {
+        if (!this.samplesData.equals(other.samplesData)) {
             return false;
         }
-        if (!Objects.equals(this.attributes, other.attributes)) {
+        if (!this.attributes.equals(other.attributes)) {
             return false;
         }
         return true;


### PR DESCRIPTION
Changed equality check of VariantSourceEntry samplesData and attributes to using more robust map equals method.