### PR TITLE
EVA-770 Don't set attributes in Variant constructor without parameters

### DIFF
--- a/biodata-formats/pom.xml
+++ b/biodata-formats/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>biodata</artifactId>
-        <version>0.4.7</version>
+        <version>0.4.8</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/biodata-models/pom.xml
+++ b/biodata-models/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>biodata</artifactId>
-        <version>0.4.7</version>
+        <version>0.4.8</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
@@ -209,6 +209,7 @@ public class Variant {
 
     public void setLength(int length) {
         this.length = length;
+        resetType();
     }
 
     public String getReference() {
@@ -219,6 +220,7 @@ public class Variant {
         this.reference = reference;
         if (reference != null && alternate != null) {
             this.length = Math.max(reference.length(), alternate.length());
+            resetType();
         }
     }
 
@@ -230,6 +232,7 @@ public class Variant {
         this.alternate = alternate;
         if (reference != null && alternate != null) {
             this.length = Math.max(reference.length(), alternate.length());
+            resetType();
         }
     }
 

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
@@ -273,7 +273,11 @@ public class Variant {
     public Map<String, Set<String>> getHgvs() {
         return hgvs;
     }
-    
+
+    public void setHgvs(Map<String, Set<String>> hgvs) {
+        this.hgvs = hgvs;
+    }
+
     public Set<String> getHgvs(String type) {
         return hgvs.get(type);
     }

--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
@@ -107,9 +107,7 @@ public class Variant {
     private VariantAnnotation annotation;
 
     
-    public Variant() {
-        this("", -1, -1, "", "");
-    }
+    public Variant() { }
     
     public Variant(String chromosome, int start, int end, String reference, String alternate) {
         if (start > end && !(reference.equals("-"))) {
@@ -219,7 +217,9 @@ public class Variant {
 
     public void setReference(String reference) {
         this.reference = reference;
-        this.length = Math.max(reference.length(), alternate.length());
+        if (reference != null && alternate != null) {
+            this.length = Math.max(reference.length(), alternate.length());
+        }
     }
 
     public String getAlternate() {
@@ -228,7 +228,9 @@ public class Variant {
 
     public void setAlternate(String alternate) {
         this.alternate = alternate;
-        this.length = Math.max(reference.length(), alternate.length());
+        if (reference != null && alternate != null) {
+            this.length = Math.max(reference.length(), alternate.length());
+        }
     }
 
     @Deprecated

--- a/biodata-tools/pom.xml
+++ b/biodata-tools/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.ac.ebi.eva</groupId>
         <artifactId>biodata</artifactId>
-        <version>0.4.7</version>
+        <version>0.4.8</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>biodata</artifactId>
-    <version>0.4.7</version>
+    <version>0.4.8</version>
     <packaging>pom</packaging>
 
     <name>Biodata</name>


### PR DESCRIPTION
The Variant constructor without parameters sets default values for fields such as HGVS. This messes up the response of the web services because Spring initializes the object using said constructor, and the real value from the database is never set.

The constructor without parameters is now completely empty, and some getters have been also modified to prevent NullPointerExceptions.