### PR TITLE
EVA-770 Prevent NPE by checking that alleles are not null

### DIFF
--- a/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
+++ b/biodata-models/src/main/java/org/opencb/biodata/models/variant/Variant.java
@@ -209,7 +209,9 @@ public class Variant {
 
     public void setLength(int length) {
         this.length = length;
-        resetType();
+        if (reference != null && alternate != null) {
+            resetType();
+        }
     }
 
     public String getReference() {


### PR DESCRIPTION
One of the changes in #11 calling `resetType()` caused a NPE when some of the alleles was null. This doesn't happen now.